### PR TITLE
Allowed empty string for config.JWT.Authenticator.

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -47,16 +47,12 @@ func NewAuthWithVersion(ctx context.Context, version string) *Auth {
 	auth := &Auth{version: version}
 	authenticatorName := config.JWT.Authenticator
 
-	if (authenticatorName == "bearer-jwt-token") {
+	if (authenticatorName == "bearer-jwt-token" || authenticatorName == "") {
 		auth.authenticator = &JWTAuthenticator{name: "bearer-jwt-token", auth: *auth}
 	} else if (authenticatorName == "bearer-okta-jwt-token") {
 		auth.authenticator = &OktaJWTAuthenticator{name: "bearer-okta-jwt-token", auth: *auth}
 	} else {
-		if (authenticatorName != "") {
-			logrus.Fatal("Authenticator `" + authenticatorName + "` is not recognized")
-		} else {
-			logrus.Fatal("Authenticator is not defined")
-		}
+		logrus.Fatal("Authenticator `" + authenticatorName + "` is not recognized")
 	}
 
 	auth.authorizer = &RolesAuthorizer{name: "bearer-jwt-token-roles", auth: *auth}


### PR DESCRIPTION
Defaulted to bearer-jwt-token for back-compat. (Thanks calavera for the suggestion.)

**- Summary**
A pull-request of pull-request, because I no longer have write access to 
https://github.com/RealSelf/git-gateway.

Pre-request of the original (netlify) repo committer, I do a better default.

Tested it locally, following instructions on README.md.

===
Look like the repo does no longer has Travis... here is the proof that I tested it locally.

![screen shot 2019-01-18 at 8 06 29 pm](https://user-images.githubusercontent.com/249558/51422023-973fe900-1b5c-11e9-8d88-b68f0519a199.png)
